### PR TITLE
Update lv_wrapper.hpp

### DIFF
--- a/src/lvgl/lvgl_cpp/lv_wrapper.hpp
+++ b/src/lvgl/lvgl_cpp/lv_wrapper.hpp
@@ -197,7 +197,7 @@ public:
      */
     PointerWrapper& operator=(LvWrapperType&& obj)
     {
-        this->lv_obj = std::swap(this->lv_obj, obj.lv_obj);
+        std::swap(this->lv_obj, obj.lv_obj);
         this->owns_ptr = obj.owns_ptr;
         return *this;
     }


### PR DESCRIPTION
std::swap 返回类型是 void，无法赋值外面。