### PR TITLE
Add Rigidbody component for game objects

### DIFF
--- a/src/games/core/components/component.hpp
+++ b/src/games/core/components/component.hpp
@@ -15,7 +15,7 @@ namespace smooth_ui_toolkit::games {
 
 class GameObject;
 
-enum class ComponentType : uint8_t { Transform = 0, Shape = 1, Area = 2 };
+enum class ComponentType : uint8_t { Transform = 0, Shape = 1, Area = 2, Rigidbody = 3 };
 
 class Component {
 public:

--- a/src/games/core/components/rigidbody.hpp
+++ b/src/games/core/components/rigidbody.hpp
@@ -1,0 +1,52 @@
+/**
+ * @file rigidbody.hpp
+ * @author Forairaaaaa
+ * @brief
+ * @version 0.1
+ * @date 2025-12-21
+ *
+ * @copyright Copyright (c) 2025
+ *
+ */
+#pragma once
+#include "games/core/game_object.hpp"
+#include "transform.hpp"
+
+namespace smooth_ui_toolkit::games {
+
+class Rigidbody : public Component {
+public:
+    static constexpr ComponentType Type = ComponentType::Rigidbody;
+
+    Rigidbody() : Component(Type) {}
+    Rigidbody(Vector2 velocity) : Component(Type), velocity(velocity) {}
+    Rigidbody(Vector2 velocity, Vector2 acceleration) : Component(Type), velocity(velocity), acceleration(acceleration)
+    {
+    }
+
+    Vector2 velocity{0, 0};
+    Vector2 acceleration{0, 0};
+    bool enabled = true;
+
+    void update(float dt) override
+    {
+        if (!enabled || !owner) {
+            return;
+        }
+
+        auto* transform = owner->get<Transform>();
+        if (!transform) {
+            return;
+        }
+
+        velocity += acceleration * dt;
+        transform->position += velocity * dt;
+    }
+
+    void applyImpulse(Vector2 impulse)
+    {
+        velocity += impulse;
+    }
+};
+
+} // namespace smooth_ui_toolkit::games

--- a/src/games/core/core.h
+++ b/src/games/core/core.h
@@ -13,6 +13,7 @@
 #include "components/transform.hpp"
 #include "components/shape.hpp"
 #include "components/area.hpp"
+#include "components/rigidbody.hpp"
 #include "game_object.hpp"
 #include "world.hpp"
 #include "frame_clock.hpp"

--- a/src/games/core/game_object.cpp
+++ b/src/games/core/game_object.cpp
@@ -25,6 +25,10 @@ void GameObject::add(std::unique_ptr<Component> comp)
         assert(get<Shape>() && "Area requires Shape");
     }
 
+    if (comp->type() == ComponentType::Rigidbody) {
+        assert(get<Transform>() && "Rigidbody requires Transform");
+    }
+
     comp->owner = this;
     components.push_back(std::move(comp));
 }


### PR DESCRIPTION
Add a lightweight Rigidbody component that integrates velocity and acceleration into an object's Transform during component updates. Include it in the game core umbrella header and require Transform before attaching it.